### PR TITLE
Adjust Active Support version requirement

### DIFF
--- a/boxxspring.gemspec
+++ b/boxxspring.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do | gem |
   gem.require_paths  = [ 'lib' ]
   gem.files          = Dir.glob( "{lib}/**/*" )
 
-  gem.add_runtime_dependency( "activesupport", "~> 4.2" )
+  gem.add_runtime_dependency( "activesupport", ">= 4.2" )
   gem.add_runtime_dependency( "addressable" )
   gem.add_runtime_dependency( "fnv", '~> 0.2' )
 


### PR DESCRIPTION
So that it doesn't create conflict when used with Rails 5.

```
Bundler could not find compatible versions for gem "activesupport":
  In snapshot (Gemfile.lock):
    activesupport (= 5.0.0.1)

  In Gemfile:
    activesupport (= 5.0.0.1) ruby

    boxxspring (>= 0) ruby depends on
      activesupport (~> 4.2) ruby
```
