### PR TITLE
Add twitter card support.

### DIFF
--- a/lib/boxxspring/resources/twitter_distribution_activity.rb
+++ b/lib/boxxspring/resources/twitter_distribution_activity.rb
@@ -1,8 +1,10 @@
 module Boxxspring
 
   class TwitterDistributionActivity < Activity
-    field  :tweet_status
-    field  :upload_video
+    field   :card_type
+    field   :creator
+    field   :tweet_status
+    field   :upload_video
   end
 
 end

--- a/lib/boxxspring/resources/twitter_distribution_task.rb
+++ b/lib/boxxspring/resources/twitter_distribution_task.rb
@@ -1,11 +1,11 @@
 module Boxxspring
 
   class TwitterDistributionTask < Task
-
     field   :distribution_id
+    field   :card_type
+    field   :creator
     field   :tweet_status
     field   :upload_video
-
   end
 
 end


### PR DESCRIPTION
Add card_type and creator fields to the json store of twitter distribution activity and task to support the change to using twitter cards in the twitter distribution worker.
